### PR TITLE
Fix csmsectionline not found error

### DIFF
--- a/csm-thesis-sections.sty
+++ b/csm-thesis-sections.sty
@@ -108,6 +108,19 @@
 		{\csm@sectionfontstyle}}
 }
 
+%% <<NOTE: Inspired by lineno.sty>>
+\newcounter{csmsectionline}
+\setcounter{csmsectionline}{0}
+\global\let\csm@ln@output\@@par
+\gdef\@@par{%
+	\ifvmode\else%
+		\ifinner\else%
+			\addtocounter{csmsectionline}{1}%
+		\fi%
+	\fi%
+	\csm@ln@output%
+}
+
 %% Convenience command for converting text to upper case in hyperref-sensitive areas
 \newcommand{\texorpdfupper}[1]{%
 	\ifx \csm@hyperref\@true%


### PR DESCRIPTION
It appears that the prior change to remove the requirement for there to be no empty sections was too aggressive, and it removed the csmsectionline counter, which is used and was reporting a non found error during compilation of tex documents using the csm thesis template.